### PR TITLE
Fix for mysql >=  5.5, TYPE=InnoDB no longer supported

### DIFF
--- a/resources/scripts/configure/voms_shared.py
+++ b/resources/scripts/configure/voms_shared.py
@@ -154,7 +154,7 @@ class VOMSDefaults:
     oracle_dialect = "org.hibernate.dialect.Oracle9Dialect"
     
     mysql_driver_class = "org.gjt.mm.mysql.Driver"
-    mysql_dialect = "org.hibernate.dialect.MySQLInnoDBDialect"
+    mysql_dialect = "org.hibernate.dialect.MySQL5InnoDBDialect"
 
 
 


### PR DESCRIPTION
We run MySQL 5.7 where as the default RHEL6 mysql is 5.1.
When creating the tables it on 5.7 it fails since  TYPE=InnoDB is deprecated in mysql 5 and dropped completly in 5.5.

This patch causes ENGINE=InnoDB to be used instead.

See http://bugs.mysql.com/bug.php?id=59288 for some background.

Not tested but should be okay for all MySQL 5 versions.
