### PR TITLE
Make sure both email addresses are lowercase in OrgDB plugin

### DIFF
--- a/src/main/java/org/glite/security/voms/admin/integration/orgdb/dao/OrgDBVOMSPersonDAOHibernate.java
+++ b/src/main/java/org/glite/security/voms/admin/integration/orgdb/dao/OrgDBVOMSPersonDAOHibernate.java
@@ -61,7 +61,7 @@ public class OrgDBVOMSPersonDAOHibernate extends OrgDBGenericHibernateDAO<VOMSOr
 				")";
 		
 		Query q = getSession().createQuery(query)
-			.setString("email", emailAddress)
+			.setString("email", emailAddress.toLowerCase())
 			.setString("experimentName", experimentName);
 		
 		return (VOMSOrgDBPerson) q.uniqueResult();


### PR DESCRIPTION
Both email addresses are being compared but only one is converted to lowercase. I am not sure if this needs to be done to other validators as well.
