### PR TITLE
Accept users with an empty institution during OrgDB Sync

### DIFF
--- a/src/main/java/org/glite/security/voms/admin/integration/orgdb/DefaultSyncStrategy.java
+++ b/src/main/java/org/glite/security/voms/admin/integration/orgdb/DefaultSyncStrategy.java
@@ -150,14 +150,15 @@ public class DefaultSyncStrategy implements
 			Participation p = orgDbPerson
 				.getValidParticipationForExperiment(experimentName);
 
-			if (u.getInstitution() == null || !u.getInstitution().equals(p.getInstitute().getOriginalName())) {
-
+			// The institute can be null sometimes
+			if (p.getInstitute() != null) {
+				if (u.getInstitution() == null || !u.getInstitution().equals(p.getInstitute().getOriginalName())) {
+					u.setInstitution(p.getInstitute().getOriginalName());
+				}
 				log
 					.debug(
 						"Institution for user {} and participation {} do not match. Updating VOMS institution field.",
 						u, p);
-				u.setInstitution(p.getInstitute().getOriginalName());
-
 			}
 		}
 	}


### PR DESCRIPTION
I've spotted several NullPointerExceptions in the logs for this line, probably due to users with an empty 'Institution' field. I assume that: 

``` java
p.getInstitute().getOriginalName()
```

is never `null`, but I am not sure myself. 
