### PR TITLE
orgdb: tentative fix for VOMS-606

### DIFF
--- a/package/rpm/voms-admin-server.spec.in
+++ b/package/rpm/voms-admin-server.spec.in
@@ -3,7 +3,7 @@
 
 %global random_num %(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 8)
 
-%global base_version 3.3.2
+%global base_version 3.3.3
 %global base_release 1
 
 %global pom_version @@POM_VERSION@@
@@ -152,6 +152,8 @@ fi
 %attr(-,voms,voms) %dir %{_localstatedir}/log/voms-admin
 
 %changelog
+* Mon Nov 3 2015 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 3.3.3-1
+- Bumped version to 3.3.3.
 * Mon Nov 3 2014 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 3.3.2-1
 - Bumped version to 3.3.2.
 

--- a/package/rpm/voms-admin-server.spec.in
+++ b/package/rpm/voms-admin-server.spec.in
@@ -152,8 +152,9 @@ fi
 %attr(-,voms,voms) %dir %{_localstatedir}/log/voms-admin
 
 %changelog
-* Mon Nov 3 2015 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 3.3.3-1
+* Tue Feb 10 2015 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 3.3.3-1
 - Bumped version to 3.3.3.
+
 * Mon Nov 3 2014 Andrea Ceccanti <andrea.ceccanti at cnaf.infn.it> - 3.3.2-1
 - Bumped version to 3.3.2.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.italiangrid</groupId>
   <artifactId>voms-admin-parent</artifactId>
-  <version>3.3.2</version>
+  <version>3.3.3</version>
   <packaging>pom</packaging>
   <name>VOMS Admin Parent POM</name>
 

--- a/voms-admin-api/pom.xml
+++ b/voms-admin-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.italiangrid</groupId>
     <artifactId>voms-admin-parent</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
   </parent>
 
   <artifactId>voms-admin-api</artifactId>

--- a/voms-admin-server/pom.xml
+++ b/voms-admin-server/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.italiangrid</groupId>
     <artifactId>voms-admin-parent</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
   </parent>
 
   <artifactId>voms-admin-server</artifactId>

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/integration/orgdb/DefaultSyncStrategy.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/integration/orgdb/DefaultSyncStrategy.java
@@ -146,9 +146,9 @@ public class DefaultSyncStrategy implements
 
       if (u.getInstitution() == null
         || !u.getInstitution().equals(
-          validParticipation.getInstitute().getOriginalName())) {
+          validParticipation.getInstitute().getName())) {
 
-        u.setInstitution(validParticipation.getInstitute().getOriginalName());
+        u.setInstitution(validParticipation.getInstitute().getName());
 
         log.debug("Institution for user {} and participation {} do not match. "
           + "Updating VOMS institution field from OrgDB record.", u, 

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/view/actions/register/orgdb/OrgDbRegisterActionSupport.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/view/actions/register/orgdb/OrgDbRegisterActionSupport.java
@@ -28,6 +28,8 @@ import org.glite.security.voms.admin.integration.PluginConfigurator;
 import org.glite.security.voms.admin.integration.PluginManager;
 import org.glite.security.voms.admin.integration.orgdb.OrgDBConfigurator;
 import org.glite.security.voms.admin.integration.orgdb.dao.OrgDBDAOFactory;
+import org.glite.security.voms.admin.integration.orgdb.database.OrgDBError;
+import org.glite.security.voms.admin.integration.orgdb.model.Institute;
 import org.glite.security.voms.admin.integration.orgdb.model.VOMSOrgDBPerson;
 import org.glite.security.voms.admin.view.actions.register.RegisterActionSupport;
 
@@ -85,11 +87,21 @@ public class OrgDbRegisterActionSupport extends RegisterActionSupport implements
     requester.setName(orgDbPerson.getFirstName());
     requester.setSurname(orgDbPerson.getName());
     requester.setEmailAddress(orgDbPerson.getPhysicalEmail());
-
-    requester.setInstitution(orgDbPerson
-      .getValidParticipationForExperiment(experimentName).getInstitute()
-      .getOriginalName());
     
+    Institute institute = orgDbPerson.getValidParticipationForExperiment(
+      experimentName).getInstitute();
+
+    if (institute == null) {
+      String errorMessage = String.format(
+        "Null institute found for valid participation."
+          + " Requester email address: %s. Experiment: %s",
+        requester.getEmailAddress(), experimentName);
+
+      throw new OrgDBError(errorMessage);
+
+    }
+    
+    requester.setInstitution(institute.getName());
     requester.setPhoneNumber(orgDbPerson.getTel1());
     requester.setAddress(orgDbPerson.getAddressForVOMS());
 

--- a/voms-container/pom.xml
+++ b/voms-container/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.italiangrid</groupId>
     <artifactId>voms-admin-parent</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
   </parent>
 
   <artifactId>voms-container</artifactId>


### PR DESCRIPTION
When CERN's HR db integration is enabled, VOMS must populate the VO members
institution field with what is found in the CERN HR db, and should use
Institute.getName() content, instead of Institute.getOriginalName() as
it used to, since orginalName can be null.

issue: https://issues.infn.it/jira/browse/VOMS-606