### PR TITLE
Fix for https://issues.infn.it/jira/browse/VOMS-641

### DIFF
--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/core/validation/strategies/impl/SuspendAUPFailingMembersStrategy.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/core/validation/strategies/impl/SuspendAUPFailingMembersStrategy.java
@@ -76,7 +76,7 @@ public class SuspendAUPFailingMembersStrategy implements
 
     } else {
 
-      if (u.getSuspended()) {
+      if (u.isSuspended()) {
 
         log
           .debug("User already suspended. Reason: {}", u.getSuspensionReason());


### PR DESCRIPTION
In case the suspended field was NULL for the user the method previously called led to a NPE.