### PR TITLE
Group-Manager role support

### DIFF
--- a/voms-admin-server/resources/scripts/configure/voms_configure.py
+++ b/voms-admin-server/resources/scripts/configure/voms_configure.py
@@ -249,6 +249,10 @@ def setup_cl_options():
                                       help="Disable manadatory group manager selection.", 
                                       default=True)
 
+    registration_opt_group.add_option("--group-manager-role", type="string", dest="group_manager_role",
+                                      help="Group manager role name. (default value: Group-Manager)",
+                                      default="Group-Manager")
+    
     registration_opt_group.add_option("--membership-request-lifetime", type="int", dest="membership_request_lifetime",
                                       help="Time (in seconds) that unconfirmed membership request are maintained in the VOMS database.",
                                       metavar="SECS", default=604800)

--- a/voms-admin-server/resources/templates/service.properties
+++ b/voms-admin-server/resources/templates/service.properties
@@ -87,7 +87,7 @@ voms.disable_membership_end_time = $disable_membership_end_time
 voms.request.vo_membership.enable_attribute_requests = $enable_attribute_requests
 
 ## Require group manager selection at registration time. When group managers are
-## enabled, should the service require that an applican selects one of the 
+## enabled, should the service require that an applicant selects one of the 
 ## managers at registration time?
 voms.request.vo_membership.require_group_manager_selection = $require_group_manager_selection
 
@@ -98,6 +98,16 @@ voms.request.vo_membership.lifetime = $membership_request_lifetime
 ## Should voms-admin send a warning email to the user when
 ## his/her uncorfimed request is removed from the database?
 voms.request.vo_membership.warn_when_expired = $membership_request_warn_when_expired
+
+## This flag is used to set a custom group manager VOMS role.
+## The group manager role is used to grant a VO user the rights
+## to be notified and handle group membership request and role assignment request
+## for VO groups. A VO user, to have such privileges, must be assigned the group manager
+## role in the VO root group *and* in the groups for which he will act as a 
+## group manager. This flag allows to set a custom name for the group manager
+## role (overriding the default "Group-Manager"). Note that the role is not 
+## created by the configure script, and must be set up by the VO administrator.
+voms.request.group_manager_role = $group_manager_role
 
 ## Should voms-admin generate gridmapfiles that encode the
 ## email part of the DN using the "emailAddress" format in addition

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/configuration/VOMSConfiguration.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/configuration/VOMSConfiguration.java
@@ -39,8 +39,6 @@ import java.util.Properties;
 
 import javax.servlet.ServletContext;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -1074,6 +1072,10 @@ public final class VOMSConfiguration {
       "localhost");
   }
 
+  public String getGroupManagerRoleName() {
+    return config.getString(VOMSConfigurationConstants.GROUP_MANAGER_ROLE_NAME,
+      "Group-Manager");
+  }
   public int getExpiringUsersWarningInterval() {
 
     String warningPeriodInDays = VOMSConfiguration

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/configuration/VOMSConfigurationConstants.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/configuration/VOMSConfigurationConstants.java
@@ -63,8 +63,9 @@ public interface VOMSConfigurationConstants {
    * at VO registration time.
    */
   public static final String VO_MEMBERSHIP_ENABLE_ATTRIBUTES_REQUEST = "voms.request.vo_membership.enable_attribute_requests";
-
   public static final String VO_MEMBERSHIP_REQUIRE_GROUP_MANAGER_SELECTION = "voms.request.vo_membership.require_group_manager_selection";
+  
+  public static final String GROUP_MANAGER_ROLE_NAME = "voms.request.group_manager_role";
   
   public static final String USER_MAX_RESULTS_PER_PAGE = "voms.pagination.user.max.results.per.page";
   public static final String ATTRIBUTES_MAX_RESULTS_PER_PAGE = "voms.pagination.attributes.max.results.per.page";

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/core/VOMSServiceConstants.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/core/VOMSServiceConstants.java
@@ -138,23 +138,6 @@ final public class VOMSServiceConstants {
 
   public static final String STATUS_MAP_KEY = "uiStatusMap";
 
-  // TAG administrators constants below
-
-  public static final String TAG_VO_MANAGER = "VO-Manager";
-
-  public static final String TAG_GROUP_MANAGER = "Group-Manager";
-
-  public static final String TAG_ROLE_MANAGER = "Role-Manager";
-
-  public static final String TAG_ATTRIBUTES_MANAGER = "Attributes-Manager";
-
-  public static final String TAG_INSTITUTE_REPRESENTATIVE = "Institute-Representative";
-
-  public static final String TAG_VO_USER = "VO-User";
-
-  public static final String USER_INFO_COMPATIBILITY_NULL_VALUE = "";
-
 }
-
 // Please do not change this line.
 // arch-tag: 47047210-5c25-4af2-b4e8-77614f1b2e66

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/notification/NotificationUtil.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/notification/NotificationUtil.java
@@ -208,4 +208,5 @@ public class NotificationUtil {
     return emailList;
 
   }
+
 }

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/notification/dispatchers/RoleMembershipNotificationDispatcher.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/notification/dispatchers/RoleMembershipNotificationDispatcher.java
@@ -23,7 +23,9 @@ package org.glite.security.voms.admin.notification.dispatchers;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
+import org.glite.security.voms.admin.configuration.VOMSConfiguration;
 import org.glite.security.voms.admin.event.Event;
 import org.glite.security.voms.admin.event.EventCategory;
 import org.glite.security.voms.admin.event.request.RoleMembershipApprovedEvent;
@@ -38,7 +40,9 @@ import org.glite.security.voms.admin.notification.messages.RequestApproved;
 import org.glite.security.voms.admin.notification.messages.RequestRejected;
 import org.glite.security.voms.admin.operations.VOMSContext;
 import org.glite.security.voms.admin.operations.VOMSPermission;
+import org.glite.security.voms.admin.persistence.dao.VOMSRoleDAO;
 import org.glite.security.voms.admin.persistence.model.GroupManager;
+import org.glite.security.voms.admin.persistence.model.VOMSRole;
 import org.glite.security.voms.admin.persistence.model.request.RoleMembershipRequest;
 
 public class RoleMembershipNotificationDispatcher extends
@@ -71,15 +75,29 @@ public class RoleMembershipNotificationDispatcher extends
 
       VOMSContext context = VOMSContext.instance(ee.getPayload().getFQAN());
 
-      List<String> admins;
+      List<String> admins = new ArrayList<String>();
 
-      if (context.getGroup().getManagers().size() != 0) {
-        admins = new ArrayList<String>();
-        for (GroupManager gm : context.getGroup().getManagers())
-          admins.add(gm.getEmailAddress());
-      } else
-        admins = NotificationUtil.getAdministratorsEmailList(context,
-          VOMSPermission.getRequestsRWPermissions());
+      VOMSRole groupManagerRole = VOMSRoleDAO.instance().findByName(
+        VOMSConfiguration.instance().getGroupManagerRoleName());
+
+      if (groupManagerRole != null) {
+
+        Set<String> groupManagersRoleEmailAddresses = groupManagerRole
+          .getMembersEmailAddresses(context.getGroup());
+
+        if (!groupManagersRoleEmailAddresses.isEmpty()) {
+          admins.addAll(groupManagersRoleEmailAddresses);
+        }
+      }
+      
+      if (admins.isEmpty()) {
+        if (context.getGroup().getManagers().size() != 0) {
+          for (GroupManager gm : context.getGroup().getManagers())
+            admins.add(gm.getEmailAddress());
+        } else
+          admins = NotificationUtil.getAdministratorsEmailList(context,
+            VOMSPermission.getRequestsRWPermissions());
+      }
 
       HandleRequest msg = new HandleRequest(req, ee.getManagementURL(), admins);
       NotificationService.instance().send(msg);

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/BaseUserAdministrativeOperation.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/BaseUserAdministrativeOperation.java
@@ -31,7 +31,7 @@ public abstract class BaseUserAdministrativeOperation extends BaseVomsOperation 
   protected VOMSUser authorizedUser;
 
   @Override
-  final AuthorizationResponse isAllowed() {
+  final protected AuthorizationResponse isAllowed() {
 
     CurrentAdmin admin = CurrentAdmin.instance();
 
@@ -44,8 +44,9 @@ public abstract class BaseUserAdministrativeOperation extends BaseVomsOperation 
     boolean usersMatch = admin.getVoUser().equals(authorizedUser);
     log.debug("Admin's user match with authorized user: " + usersMatch);
 
-    if (usersMatch)
+    if (usersMatch) {
       return AuthorizationResponse.permit();
+    }
 
     return super.isAllowed();
 

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/BaseVomsOperation.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/BaseVomsOperation.java
@@ -111,7 +111,7 @@ public abstract class BaseVomsOperation implements VOMSOperation {
     __requiredPermissions = new HashMap();
   }
 
-  AuthorizationResponse isAllowed() {
+  protected AuthorizationResponse isAllowed() {
 
     CurrentAdmin admin = CurrentAdmin.instance();
 

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/CurrentAdmin.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/CurrentAdmin.java
@@ -27,10 +27,13 @@ import java.util.regex.Pattern;
 import org.glite.security.voms.admin.configuration.VOMSConfiguration;
 import org.glite.security.voms.admin.configuration.VOMSConfigurationConstants;
 import org.glite.security.voms.admin.persistence.dao.VOMSAdminDAO;
+import org.glite.security.voms.admin.persistence.dao.VOMSRoleDAO;
 import org.glite.security.voms.admin.persistence.dao.VOMSUserDAO;
 import org.glite.security.voms.admin.persistence.model.ACL;
 import org.glite.security.voms.admin.persistence.model.VOMSAdmin;
 import org.glite.security.voms.admin.persistence.model.VOMSCA;
+import org.glite.security.voms.admin.persistence.model.VOMSGroup;
+import org.glite.security.voms.admin.persistence.model.VOMSRole;
 import org.glite.security.voms.admin.persistence.model.VOMSUser;
 import org.glite.security.voms.admin.util.DNUtil;
 import org.italiangrid.utils.voms.CurrentSecurityContext;
@@ -329,6 +332,30 @@ public class CurrentAdmin {
       return null;
   }
 
+  public boolean hasRole(VOMSGroup group, String roleName){
+    VOMSRole role = VOMSRoleDAO.instance().findByName(roleName);
+    
+    if (role == null) {
+      return false;
+    }
+    
+    return hasRole(group, role);
+  }
+  
+  public boolean hasRole(VOMSGroup group, VOMSRole role){
+    if (getVoUser() == null){
+      return false;
+    }
+    
+    if (getVoUser().isMember(group)){
+      return getVoUser().hasRole(group, role);
+    } 
+    
+    return false;
+      
+  }
+  
+  
   public String getRealEmailAddress() {
 
     VOMSSecurityContext theContext = (VOMSSecurityContext) CurrentSecurityContext

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/VOMSContext.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/VOMSContext.java
@@ -80,18 +80,6 @@ public class VOMSContext {
     if (contextString == null)
       throw new IllegalArgumentException("null is not a valid VOMS context!");
 
-    if (PathNamingScheme.isGroup(contextString)) {
-      VOMSGroup g = VOMSGroupDAO.instance().findByName(contextString);
-
-      if (g == null)
-        throw new NoSuchGroupException("Group '"
-          + PathNamingScheme.getGroupName(contextString)
-          + "' is not defined for this vo.");
-
-      return new VOMSContext(g, null);
-
-    }
-
     if (PathNamingScheme.isQualifiedRole(contextString)) {
 
       VOMSGroup g = VOMSGroupDAO.instance().findByName(
@@ -110,6 +98,18 @@ public class VOMSContext {
           + "' is not defined for this vo.");
 
       return new VOMSContext(g, r);
+    }
+    
+    if (PathNamingScheme.isGroup(contextString)) {
+      VOMSGroup g = VOMSGroupDAO.instance().findByName(contextString);
+
+      if (g == null)
+        throw new NoSuchGroupException("Group '"
+          + PathNamingScheme.getGroupName(contextString)
+          + "' is not defined for this vo.");
+
+      return new VOMSContext(g, null);
+
     }
 
     throw new IllegalArgumentException(

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/requests/GroupManagerRoleHolderOperation.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/requests/GroupManagerRoleHolderOperation.java
@@ -1,0 +1,75 @@
+package org.glite.security.voms.admin.operations.requests;
+
+import org.glite.security.voms.admin.configuration.VOMSConfiguration;
+import org.glite.security.voms.admin.error.IllegalStateException;
+import org.glite.security.voms.admin.operations.AuthorizationResponse;
+import org.glite.security.voms.admin.operations.CurrentAdmin;
+import org.glite.security.voms.admin.persistence.model.VOMSGroup;
+import org.glite.security.voms.admin.persistence.model.VOMSRole;
+import org.glite.security.voms.admin.persistence.model.VOMSUser;
+import org.glite.security.voms.admin.persistence.model.request.GroupScopeRequest;
+import org.glite.security.voms.admin.persistence.model.request.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class GroupManagerRoleHolderOperation<T extends Request> extends
+  BaseHandleRequestOperation<T> {
+
+  public static final Logger LOGGER = LoggerFactory
+    .getLogger(GroupManagerRoleHolderOperation.class);
+
+  public GroupManagerRoleHolderOperation(T request, DECISION decision) {
+
+    super(request, decision);
+
+  }
+
+  @Override
+  final protected AuthorizationResponse isAllowed() {
+
+    CurrentAdmin admin = CurrentAdmin.instance();
+
+    if (!admin.isVoUser()) {
+      LOGGER.debug("Current admin has no corresponding VO user.");
+      return super.isAllowed();
+    }
+
+    final VOMSUser user = admin.getVoUser();
+    
+    String groupManagerRoleName = VOMSConfiguration
+      .instance().getGroupManagerRoleName();
+
+    VOMSRole gmRole = findRoleByName(groupManagerRoleName);
+
+    if (gmRole == null) {
+      LOGGER.debug("{} role is not defined, falling back to ACL authz.",
+        groupManagerRoleName);
+
+      return super.isAllowed();
+    }
+
+    if (!(request instanceof GroupScopeRequest)) {
+      throw new IllegalStateException(
+        "This is a bug: this class should only be instantiated "
+          + "to handle group scoped requests.");
+    }
+
+    GroupScopeRequest gr = (GroupScopeRequest) request;
+    VOMSGroup requestGroup = findGroupByName(gr.getGroupName());
+    
+    if (requestGroup.isRootGroup()){
+      return super.isAllowed();
+    }
+    
+    if (!user.isMember(requestGroup)){
+      return super.isAllowed();
+    }
+    
+    if (!user.hasRole(requestGroup, gmRole)) {
+      return super.isAllowed();
+    }
+
+    return AuthorizationResponse.permit();
+  }
+
+}

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/requests/HandleRoleMembershipRequestOperation.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/operations/requests/HandleRoleMembershipRequestOperation.java
@@ -23,9 +23,11 @@ package org.glite.security.voms.admin.operations.requests;
 import org.glite.security.voms.admin.event.EventManager;
 import org.glite.security.voms.admin.event.request.RoleMembershipApprovedEvent;
 import org.glite.security.voms.admin.event.request.RoleMembershipRejectedEvent;
+import org.glite.security.voms.admin.event.user.membership.RoleAssignedEvent;
 import org.glite.security.voms.admin.operations.VOMSContext;
 import org.glite.security.voms.admin.operations.VOMSPermission;
 import org.glite.security.voms.admin.operations.users.AssignRoleOperation;
+import org.glite.security.voms.admin.persistence.dao.VOMSUserDAO;
 import org.glite.security.voms.admin.persistence.model.VOMSGroup;
 import org.glite.security.voms.admin.persistence.model.VOMSRole;
 import org.glite.security.voms.admin.persistence.model.VOMSUser;
@@ -33,7 +35,7 @@ import org.glite.security.voms.admin.persistence.model.request.RoleMembershipReq
 import org.glite.security.voms.admin.persistence.model.request.Request.STATUS;
 
 public class HandleRoleMembershipRequestOperation extends
-  BaseHandleRequestOperation<RoleMembershipRequest> {
+  GroupManagerRoleHolderOperation<RoleMembershipRequest> {
 
   public HandleRoleMembershipRequestOperation(RoleMembershipRequest request,
     DECISION decision) {
@@ -50,10 +52,11 @@ public class HandleRoleMembershipRequestOperation extends
     VOMSGroup g = findGroupByName(request.getGroupName());
     VOMSRole r = findRoleByName(request.getRoleName());
 
-    AssignRoleOperation.instance(u, g, r).execute();
+    VOMSUserDAO.instance().assignRole(u, g, r);
 
     approveRequest();
 
+    EventManager.instance().dispatch(new RoleAssignedEvent(u,g,r));
     EventManager.instance().dispatch(new RoleMembershipApprovedEvent(request));
 
   }

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/HasGroupManagerRoleTag.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/HasGroupManagerRoleTag.java
@@ -1,0 +1,75 @@
+package org.glite.security.voms.admin.taglib;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.TagSupport;
+
+import org.glite.security.voms.admin.configuration.VOMSConfiguration;
+import org.glite.security.voms.admin.error.NotFoundException;
+import org.glite.security.voms.admin.operations.CurrentAdmin;
+import org.glite.security.voms.admin.operations.VOMSContext;
+
+public class HasGroupManagerRoleTag extends TagSupport {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
+
+  String group;
+  String var;
+
+  final String groupManagerRoleName;
+
+  public HasGroupManagerRoleTag() {
+
+    groupManagerRoleName = VOMSConfiguration.instance()
+      .getGroupManagerRoleName();
+  }
+
+  @Override
+  public int doStartTag() throws JspException {
+
+    VOMSContext ctxt;
+
+    try {
+
+      ctxt = TagUtils.buildContext(group + "/Role=" + groupManagerRoleName);
+
+    } catch (NotFoundException e) {
+      pageContext.setAttribute(var, Boolean.FALSE);
+      return SKIP_BODY;
+    }
+
+    boolean hasRole = CurrentAdmin.instance().hasRole(ctxt.getGroup(),
+      ctxt.getRole());
+    pageContext.setAttribute(var, new Boolean(hasRole));
+    return SKIP_BODY;
+  }
+
+  @Override
+  public int doEndTag() throws JspException {
+
+    return EVAL_PAGE;
+  }
+
+  public String getGroup() {
+
+    return group;
+  }
+
+  public void setGroup(String group) {
+
+    this.group = group;
+  }
+
+  public String getVar() {
+
+    return var;
+  }
+
+  public void setVar(String var) {
+
+    this.var = var;
+  }
+
+}

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/HasRoleTag.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/HasRoleTag.java
@@ -1,0 +1,68 @@
+package org.glite.security.voms.admin.taglib;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.TagSupport;
+
+import org.glite.security.voms.admin.error.NotFoundException;
+import org.glite.security.voms.admin.operations.CurrentAdmin;
+import org.glite.security.voms.admin.operations.VOMSContext;
+
+public class HasRoleTag extends TagSupport {
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 1L;
+
+  String role;
+  String var;
+
+  @Override
+  public int doStartTag() throws JspException {
+
+    VOMSContext ctxt;
+    try {
+
+      ctxt = TagUtils.buildContext(role);
+
+    } catch (NotFoundException e) {
+
+      pageContext.setAttribute(var, Boolean.FALSE);
+      return SKIP_BODY;
+    }
+
+    boolean hasRole = CurrentAdmin.instance().hasRole(ctxt.getGroup(),
+      ctxt.getRole());
+    pageContext.setAttribute(var, new Boolean(hasRole));
+    return SKIP_BODY;
+
+  }
+
+  @Override
+  public int doEndTag() throws JspException {
+
+    return EVAL_PAGE;
+
+  }
+
+  public String getRole() {
+
+    return role;
+  }
+
+  public void setRole(String role) {
+
+    this.role = role;
+  }
+
+  public String getVar() {
+
+    return var;
+  }
+
+  public void setVar(String var) {
+
+    this.var = var;
+  }
+
+}

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/TagUtils.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/TagUtils.java
@@ -75,6 +75,7 @@ public class TagUtils {
 
   }
 
+
   public static VOMSContext buildContext(String context) throws JspException {
 
     if (context.equals("vo"))

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/voms-admin.tld
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/taglib/voms-admin.tld
@@ -199,6 +199,46 @@
         </attribute>
     </tag>
     <tag>
+      <name>hasRole</name>
+      <tag-class>org.glite.security.voms.admin.taglib.HasRoleTag</tag-class>
+      <body-content>empty</body-content>
+      <variable>
+            <name-from-attribute>var</name-from-attribute>
+            <variable-class>java.lang.Boolean</variable-class>
+            <scope>AT_END</scope>
+        </variable>
+        <attribute>
+            <name>role</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>var</name>
+            <required>true</required>
+            <rtexprvalue>false</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
+      <name>hasGroupManagerRole</name>
+      <tag-class>org.glite.security.voms.admin.taglib.HasGroupManagerRoleTag</tag-class>
+      <body-content>empty</body-content>
+      <variable>
+            <name-from-attribute>var</name-from-attribute>
+            <variable-class>java.lang.Boolean</variable-class>
+            <scope>AT_END</scope>
+        </variable>
+        <attribute>
+            <name>group</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>var</name>
+            <required>true</required>
+            <rtexprvalue>false</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
         <name>panel</name>
         <tag-class>org.glite.security.voms.admin.taglib.PanelTag</tag-class>
         <body-content>JSP</body-content>

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/view/actions/BaseAction.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/view/actions/BaseAction.java
@@ -25,11 +25,14 @@ package org.glite.security.voms.admin.view.actions;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.glite.security.voms.admin.configuration.VOMSConfiguration;
 import org.glite.security.voms.admin.error.NullArgumentException;
 import org.glite.security.voms.admin.operations.groups.FindGroupOperation;
 import org.glite.security.voms.admin.operations.roles.FindRoleOperation;
 import org.glite.security.voms.admin.operations.users.FindUserOperation;
 import org.glite.security.voms.admin.persistence.dao.VOMSAdminDAO;
+import org.glite.security.voms.admin.persistence.dao.VOMSGroupDAO;
+import org.glite.security.voms.admin.persistence.dao.VOMSRoleDAO;
 import org.glite.security.voms.admin.persistence.model.VOMSAdmin;
 import org.glite.security.voms.admin.persistence.model.VOMSGroup;
 import org.glite.security.voms.admin.persistence.model.VOMSRole;
@@ -82,6 +85,18 @@ public class BaseAction extends ActionSupport implements ValidationAware {
 
     return VOMSAdminDAO.instance().getById(id);
 
+  }
+
+  protected VOMSGroup getVORootGroup() {
+
+    return VOMSGroupDAO.instance().getVOGroup();
+  }
+
+  protected VOMSRole getGroupManagerRole() {
+
+    return VOMSRoleDAO.instance().findByName(VOMSConfiguration
+      .instance().getGroupManagerRoleName());
+    
   }
 
   protected VOMSGroup groupById(Long id) {

--- a/voms-admin-server/src/main/java/org/glite/security/voms/admin/view/actions/home/LoginAction.java
+++ b/voms-admin-server/src/main/java/org/glite/security/voms/admin/view/actions/home/LoginAction.java
@@ -23,6 +23,8 @@ import org.apache.struts2.convention.annotation.ParentPackage;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.convention.annotation.Results;
 import org.glite.security.voms.admin.operations.CurrentAdmin;
+import org.glite.security.voms.admin.persistence.model.VOMSGroup;
+import org.glite.security.voms.admin.persistence.model.VOMSRole;
 import org.glite.security.voms.admin.view.actions.BaseAction;
 
 @ParentPackage(value = "base")
@@ -44,10 +46,15 @@ public class LoginAction extends BaseAction {
   public String execute() throws Exception {
 
     CurrentAdmin admin = CurrentAdmin.instance();
-
+    VOMSGroup rootGroup = getVORootGroup();
+    VOMSRole groupManagerRole = getGroupManagerRole();
+    
     if (admin.isVOAdmin())
       return "admin-home";
-    else if (admin.isVoUser())
+    else if (groupManagerRole != null && 
+      admin.hasRole(rootGroup, groupManagerRole)){
+      return "admin-home";
+    } else if (admin.isVoUser())
       return "user-home";
     else if (admin.isUnauthenticated())
       return "unauthenticated";

--- a/voms-admin-server/src/main/webapp/WEB-INF/p/admin/home.jsp
+++ b/voms-admin-server/src/main/webapp/WEB-INF/p/admin/home.jsp
@@ -37,9 +37,15 @@
 		</div>
 	</s:if>
 	
-	<voms:hasPermissions var="canManage" context="vo" permission="REQUESTS_READ|REQUESTS_WRITE"/>
+  <voms:hasGroupManagerRole 
+    var="hasGroupManagerRole" 
+    group="vo"/>
+  
+	<voms:hasPermissions var="canManage" 
+    context="vo" 
+    permission="REQUESTS_READ|REQUESTS_WRITE"/>
 	
-	<s:if test="#attr.canManage">
+	<s:if test="#attr.canManage or #attr.hasGroupManagerRole">
 	  <tiles2:insertTemplate template="requests.jsp"/>
 	</s:if>
 	<s:else>

--- a/voms-admin-server/src/main/webapp/WEB-INF/p/admin/requests.jsp
+++ b/voms-admin-server/src/main/webapp/WEB-INF/p/admin/requests.jsp
@@ -1,7 +1,6 @@
 <%@include file="/WEB-INF/p/shared/taglibs.jsp"%>
 
 <tiles2:insertTemplate template="../shared/errorsAndMessages.jsp" />
-
 <s:if test="pendingRequests.empty">
   No pending requests.
 </s:if>
@@ -14,7 +13,7 @@
     action="bulk-decision"
     namespace="/admin">
     <s:token />
-    <table class="table">
+    <table class="table" style="clear: both">
       <thead>
         <tr class="req-toolbar">
           <th><input

--- a/voms-admin-server/src/main/webapp/WEB-INF/voms-admin.tld
+++ b/voms-admin-server/src/main/webapp/WEB-INF/voms-admin.tld
@@ -199,6 +199,46 @@
         </attribute>
     </tag>
     <tag>
+      <name>hasRole</name>
+      <tag-class>org.glite.security.voms.admin.taglib.HasRoleTag</tag-class>
+      <body-content>empty</body-content>
+      <variable>
+            <name-from-attribute>var</name-from-attribute>
+            <variable-class>java.lang.Boolean</variable-class>
+            <scope>AT_END</scope>
+        </variable>
+        <attribute>
+            <name>role</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>var</name>
+            <required>true</required>
+            <rtexprvalue>false</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
+      <name>hasGroupManagerRole</name>
+      <tag-class>org.glite.security.voms.admin.taglib.HasGroupManagerRoleTag</tag-class>
+      <body-content>empty</body-content>
+      <variable>
+            <name-from-attribute>var</name-from-attribute>
+            <variable-class>java.lang.Boolean</variable-class>
+            <scope>AT_END</scope>
+        </variable>
+        <attribute>
+            <name>group</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>var</name>
+            <required>true</required>
+            <rtexprvalue>false</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
         <name>panel</name>
         <tag-class>org.glite.security.voms.admin.taglib.PanelTag</tag-class>
         <body-content>JSP</body-content>


### PR DESCRIPTION
Group-Manager role grants VO users that owns it in the VO root
group and in a given sugroup G the rights to handle group membership
requests for group G.

The name of the role used as Group manager role can be defined by the VO
administrator, with the default being "Group-Manager".

Issue: https://issues.infn.it/jira/browse/VOMS-655