### PR TITLE
info-providers: use hostname -f to find the service host.

### DIFF
--- a/voms-admin-server/resources/scripts/info-providers/voms-config-info-providers.sh
+++ b/voms-admin-server/resources/scripts/info-providers/voms-config-info-providers.sh
@@ -18,7 +18,7 @@
 
 
 # determine the hostname
-SERVICE_HOST=`hostname`
+SERVICE_HOST=`hostname -f`
  
 # configuration template
 INFO_PROVIDER_CONF_TEMPLATE_DIR="/usr/share/voms-admin/info-providers"


### PR DESCRIPTION
Assuming that hostname is always the FQDN is incorrect and cause troubles on nodes where "hostname == shortname" and "hostname -f == fqdn"
